### PR TITLE
Enable formatting when UTF-8 encoding is used

### DIFF
--- a/fmt_text.c
+++ b/fmt_text.c
@@ -44,6 +44,7 @@ vPrintFMT(FILE *pFile,
 	const char *szString, size_t tStringLength, USHORT usFontstyle)
 {
 	const UCHAR	*pucByte, *pucStart, *pucLast, *pucNonSpace;
+	BOOL bUTF8 = FALSE;
 
 	fail(szString == NULL);
 
@@ -52,8 +53,7 @@ vPrintFMT(FILE *pFile,
 	}
 
 	if (eEncoding == encoding_utf_8) {
-		fprintf(pFile, "%.*s", (int)tStringLength, szString);
-		return;
+		bUTF8 = TRUE;
 	}
 
 	if (ucNbsp == 0) {
@@ -64,14 +64,14 @@ vPrintFMT(FILE *pFile,
 	pucStart = (UCHAR *)szString;
 	pucLast = pucStart + tStringLength - 1;
 	pucNonSpace = pucLast;
-	while ((*pucNonSpace == (UCHAR)' ' || *pucNonSpace == ucNbsp) &&
+	while ((*pucNonSpace == (UCHAR)' ' || (!bUTF8 && *pucNonSpace == ucNbsp)) &&
 	       pucNonSpace > pucStart) {
 		pucNonSpace--;
 	}
 
 	/* 1: The spaces at the start */
 	pucByte = pucStart;
-	while ((*pucByte == (UCHAR)' ' || *pucByte == ucNbsp) &&
+	while ((*pucByte == (UCHAR)' ' || (!bUTF8 && *pucByte == ucNbsp)) &&
 	       pucByte <= pucLast) {
 		(void)putc(' ', pFile);
 		pucByte++;
@@ -95,7 +95,7 @@ vPrintFMT(FILE *pFile,
 
 	/* 3: The text itself */
 	while (pucByte <= pucNonSpace) {
-		if (*pucByte == ucNbsp) {
+		if (!bUTF8 && *pucByte == ucNbsp) {
 			(void)putc(' ', pFile);
 		} else {
 			(void)putc((char)*pucByte, pFile);


### PR DESCRIPTION
This implementation allows the NBSP symbol (0x00A0) to be passed to the UTF-8 output stream ( 0xC2 0xA0 ).

Only the non UTF-8 character sets would be in need to transform the NBSP (0xA0) into an actual space (0x20) - what was the purpose of the original code, and as it was written, it was understandably not compatible with UTF-8 streams (since the 0xC2 0xA0 would be turned into a 0xC2 0x20 - NBSP matcher worked on byte level, not in multi-byte mode).

Support was created as per a local forum post:
https://forum.root.cz/index.php?topic=28486.msg398820