### PR TITLE
Fix macOS resource path and unsafe temp file creation

### DIFF
--- a/Makefile.Linux
+++ b/Makefile.Linux
@@ -16,7 +16,7 @@ OPT	= -O2
 
 LDLIBS	=
 
-CFLAGS	= -Wall -pedantic $(OPT) -D$(DB)
+CFLAGS	= -Wall -pedantic $(OPT) -D$(DB) $(EXTRACFLAGS)
 LDFLAGS	=
 
 OBJS	=\
@@ -36,8 +36,11 @@ PROGS =\
 LOCAL_INSTALL_DIR = $(HOME)/bin
 LOCAL_RESOURCES_DIR = $(HOME)/.antiword
 
-GLOBAL_INSTALL_DIR = /usr/bin
-GLOBAL_RESOURCES_DIR = /usr/share/antiword
+PREFIX = /usr
+GLOBAL_INSTALL_DIR = $(PREFIX)/bin
+GLOBAL_RESOURCES_DIR = $(PREFIX)/share/antiword
+
+EXTRACFLAGS = -DGLOBAL_ANTIWORD_DIR='"$(GLOBAL_RESOURCES_DIR)"'
 
 all:		$(PROGS)
 

--- a/antiword.h
+++ b/antiword.h
@@ -219,12 +219,16 @@
 #define GLOBAL_ANTIWORD_DIR	"/sys/lib/antiword"
 #define ANTIWORD_DIR		"lib/antiword"
 #define FONTNAMES_FILE		"fontnames"
-#elif defined(__sun__)
+#elif defined(__sun__) || defined(__APPLE__)
+#if !defined(GLOBAL_ANTIWORD_DIR)
 #define GLOBAL_ANTIWORD_DIR	"/usr/local/share/antiword"
+#endif
 #define ANTIWORD_DIR		".antiword"
 #define FONTNAMES_FILE		"fontnames"
 #else	/* All others */
+#if !defined(GLOBAL_ANTIWORD_DIR)
 #define GLOBAL_ANTIWORD_DIR	"/usr/share/antiword"
+#endif
 #define ANTIWORD_DIR		".antiword"
 #define FONTNAMES_FILE		"fontnames"
 #endif /* __dos */

--- a/dib2eps.c
+++ b/dib2eps.c
@@ -14,6 +14,10 @@
  */
 
 #include <stdio.h>
+#if defined(DEBUG)
+#include <stdlib.h>
+#include <unistd.h>
+#endif /* DEBUG */
 #include "antiword.h"
 
 
@@ -447,19 +451,22 @@ vDecodeDIB(FILE *pInFile, FILE *pOutFile, const imagedata_type *pImg)
 static void
 vCopy2File(FILE *pInFile, ULONG ulFileOffset, size_t tPictureLen)
 {
-	static int	iPicCounter = 0;
 	FILE	*pOutFile;
 	size_t	tIndex;
-	int	iTmp;
-	char	szFilename[30];
+	int	iTmp, iFd;
+	char	szFilename[] = "/tmp/antiword_XXXXXX.bmp";
 
 	if (!bSetDataOffset(pInFile, ulFileOffset)) {
 		return;
 	}
 
-	sprintf(szFilename, "/tmp/pic/pic%04d.bmp", ++iPicCounter);
-	pOutFile = fopen(szFilename, "wb");
+	iFd = mkstemps(szFilename, 4);
+	if (iFd < 0) {
+		return;
+	}
+	pOutFile = fdopen(iFd, "wb");
 	if (pOutFile == NULL) {
+		close(iFd);
 		return;
 	}
 	/* Turn a dib into a bmp by adding a fake 14 byte header */

--- a/jpeg2eps.c
+++ b/jpeg2eps.c
@@ -8,11 +8,11 @@
  */
 
 #include <stdio.h>
-#include "antiword.h"
-
 #if defined(DEBUG)
-static int	iPicCounter = 0;
+#include <stdlib.h>
+#include <unistd.h>
 #endif /* DEBUG */
+#include "antiword.h"
 
 
 #if defined(DEBUG)
@@ -24,16 +24,20 @@ vCopy2File(FILE *pFile, ULONG ulFileOffset, size_t tPictureLen)
 {
 	FILE	*pOutFile;
 	size_t	tIndex;
-	int	iTmp;
-	char	szFilename[30];
+	int	iTmp, iFd;
+	char	szFilename[] = "/tmp/antiword_XXXXXX.jpg";
 
 	if (!bSetDataOffset(pFile, ulFileOffset)) {
 		return;
 	}
 
-	sprintf(szFilename, "/tmp/pic/pic%04d.jpg", ++iPicCounter);
-	pOutFile = fopen(szFilename, "wb");
+	iFd = mkstemps(szFilename, 4);
+	if (iFd < 0) {
+		return;
+	}
+	pOutFile = fdopen(iFd, "wb");
 	if (pOutFile == NULL) {
+		close(iFd);
 		return;
 	}
 	for (tIndex = 0; tIndex < tPictureLen; tIndex++) {

--- a/png2eps.c
+++ b/png2eps.c
@@ -9,11 +9,11 @@
 
 #include <stdio.h>
 #include <ctype.h>
-#include "antiword.h"
-
 #if defined(DEBUG)
-static int	iPicCounter = 0;
+#include <stdlib.h>
+#include <unistd.h>
 #endif /* DEBUG */
+#include "antiword.h"
 
 
 /*
@@ -127,16 +127,20 @@ vCopy2File(FILE *pFile, ULONG ulFileOffset, size_t tPictureLen)
 {
 	FILE	*pOutFile;
 	size_t	tIndex;
-	int	iTmp;
-	char	szFilename[30];
+	int	iTmp, iFd;
+	char	szFilename[] = "/tmp/antiword_XXXXXX.png";
 
 	if (!bSetDataOffset(pFile, ulFileOffset)) {
 		return;
 	}
 
-	sprintf(szFilename, "/tmp/pic/pic%04d.png", ++iPicCounter);
-	pOutFile = fopen(szFilename, "wb");
+	iFd = mkstemps(szFilename, 4);
+	if (iFd < 0) {
+		return;
+	}
+	pOutFile = fdopen(iFd, "wb");
 	if (pOutFile == NULL) {
+		close(iFd);
 		return;
 	}
 	for (tIndex = 0; tIndex < tPictureLen; tIndex++) {


### PR DESCRIPTION
## Summary

- **Fix macOS mapping file lookup** — Add `__APPLE__` detection in `antiword.h` so macOS defaults to `/usr/local/share/antiword` instead of `/usr/share/antiword`. This fixes the long-standing Homebrew issue where `antiword` could not find its mapping files after installation (see [Homebrew/legacy-homebrew#898](https://github.com/Homebrew/legacy-homebrew/issues/898) and [Homebrew/legacy-homebrew#19316](https://github.com/Homebrew/legacy-homebrew/issues/19316)).
- **Make `GLOBAL_ANTIWORD_DIR` configurable at build time** — Wrap the `#define` in `#if !defined(...)` guards and pass `-DGLOBAL_ANTIWORD_DIR` from the Makefile via a new `PREFIX` variable. Package managers can now do `make PREFIX=/usr/local global_install` and the compiled-in search path will match the install location.
- **Fix unsafe temp file creation in DEBUG builds** — Replace predictable `/tmp/pic/pic%04d.{bmp,jpg,png}` filenames in `dib2eps.c`, `jpeg2eps.c`, and `png2eps.c` with `mkstemps()` + `fdopen()`, eliminating symlink attacks and TOCTOU race conditions.

## Test plan

- [x] Verified `make clean && make` compiles without errors on macOS (Apple clang)
- [x] Verified `make PREFIX=/usr/local` embeds `/usr/local/share/antiword` in the binary (`strings antiword | grep share/antiword`)
- [x] Verified default `make` (PREFIX=/usr) still embeds `/usr/share/antiword`
- [ ] Verify `make global_install PREFIX=/usr/local` installs resources and binary correctly
- [ ] Verify `antiword` finds mapping files after Homebrew-style installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)